### PR TITLE
Added some code that estimates Mb position for pseudomarkers

### DIFF
--- a/src/geneobject.rs
+++ b/src/geneobject.rs
@@ -453,6 +453,8 @@ impl Genome {
             let next_locus = &chromosome[(ix + 1).min(chromosome.len() - 1)];
             let mut first = true;
 
+            let mut cur_mb = locus.marker.mega_basepair.unwrap_or(0.0);
+
             loop {
                 if first {
                     interval_chromosome.push(locus.clone());
@@ -460,6 +462,14 @@ impl Genome {
                     let mut new_locus = locus.clone();
                     new_locus.marker.name = String::from(" - ");
                     new_locus.marker.centi_morgan = cur_cm;
+
+                    if (cur_mb != 0.0) {
+                        let next_mb = next_locus.marker.mega_basepair.unwrap();
+                        let mb_step = (next_mb - cur_mb*interval)/(next_locus.cm() - locus.cm());
+                        cur_mb = mb_step + cur_mb;
+                        new_locus.marker.mega_basepair = Some(cur_mb);
+                    }
+
                     for (geno_ix, _geno) in locus.genotype.iter().enumerate() {
                         let (prev, next) = find_adj_known(geno_ix, ix);
                         Locus::estimate_unknown_locus(


### PR DESCRIPTION
While this works, I'm pretty sure there is a better way to do the "checking if there are Mb positions in the genofile" part of this (and this would also throw an error at line 467 if there were ever a situation where some markers had Mb positions and others didn't, though I don't think that ever happens).  I noticed that Dataset has an attribute "has_mb," but I'm not sure if/how it can be accessed within the scope of chromosome_interval.

The logic for getting the mb positions is just taken from the original qtlreaper.